### PR TITLE
Exercise 04 - Context

### DIFF
--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -1,13 +1,17 @@
-import React from 'react';
+import React from "react";
 
-import ToastPlayground from '../ToastPlayground';
-import Footer from '../Footer';
+import ToastProvider from "../ToastProvider/ToastProvider";
+
+import ToastPlayground from "../ToastPlayground";
+import Footer from "../Footer";
 
 function App() {
   return (
     <>
-      <ToastPlayground />
-      <Footer />
+      <ToastProvider>
+        <ToastPlayground />
+        <Footer />
+      </ToastProvider>
     </>
   );
 }

--- a/src/components/Toast/Toast.js
+++ b/src/components/Toast/Toast.js
@@ -10,6 +10,7 @@ import {
 import VisuallyHidden from "../VisuallyHidden";
 
 import styles from "./Toast.module.css";
+import { ToastContext } from "../ToastProvider/ToastProvider";
 
 const ICONS_BY_VARIANT = {
   notice: Info,
@@ -18,7 +19,8 @@ const ICONS_BY_VARIANT = {
   error: AlertOctagon,
 };
 
-function Toast({ id, dismissToast, children, variant }) {
+function Toast({ id, children, variant }) {
+  const { dismissToast } = React.useContext(ToastContext);
 
   // If type is supplied, render icon accordingly
   const Icon = variant ? ICONS_BY_VARIANT[variant] : "Info";

--- a/src/components/ToastPlayground/ToastPlayground.js
+++ b/src/components/ToastPlayground/ToastPlayground.js
@@ -16,7 +16,7 @@ function ToastPlayground() {
   const [message, setMessage] = React.useState(defaultMessage);
   const [variant, setVariant] = React.useState(defaultVariantOption);
 
-  const {toasts, setToasts} = React.useContext(ToastContext)
+  const {toasts, setToasts, dismissToast} = React.useContext(ToastContext)
 
   function addToastToShelf(event) {
     event.preventDefault();
@@ -30,13 +30,6 @@ function ToastPlayground() {
     setToasts([...toasts, nextToast]);
     setMessage(defaultMessage);
     setVariant(defaultVariantOption);
-  }
-
-  function dismissToast(id) {
-    const nextToasts = toasts.filter((item) => {
-      return item.id !== id;
-    });
-    setToasts(nextToasts);
   }
 
   return (

--- a/src/components/ToastPlayground/ToastPlayground.js
+++ b/src/components/ToastPlayground/ToastPlayground.js
@@ -1,10 +1,11 @@
 import React from "react";
 
 import Button from "../Button";
-import Toast from "../Toast";
 
 import styles from "./ToastPlayground.module.css";
 import ToastShelf from "../ToastShelf/ToastShelf";
+
+import { ToastContext } from "../ToastProvider/ToastProvider";
 
 const VARIANT_OPTIONS = ["notice", "warning", "success", "error"];
 
@@ -15,7 +16,7 @@ function ToastPlayground() {
   const [message, setMessage] = React.useState(defaultMessage);
   const [variant, setVariant] = React.useState(defaultVariantOption);
 
-  const [toasts, setToasts] = React.useState([]);
+  const {toasts, setToasts} = React.useContext(ToastContext)
 
   function addToastToShelf(event) {
     event.preventDefault();

--- a/src/components/ToastPlayground/ToastPlayground.js
+++ b/src/components/ToastPlayground/ToastPlayground.js
@@ -13,21 +13,15 @@ function ToastPlayground() {
   const defaultMessage = "";
   const defaultVariantOption = VARIANT_OPTIONS[0];
 
+  const { createToast } = React.useContext(ToastContext);
   const [message, setMessage] = React.useState(defaultMessage);
   const [variant, setVariant] = React.useState(defaultVariantOption);
 
-  const {toasts, setToasts, dismissToast} = React.useContext(ToastContext)
-
-  function addToastToShelf(event) {
+  function handleCreateToast(event) {
     event.preventDefault();
 
-    const nextToast = {
-      id: crypto.randomUUID(),
-      message,
-      variant,
-    };
+    createToast(message, variant);
 
-    setToasts([...toasts, nextToast]);
     setMessage(defaultMessage);
     setVariant(defaultVariantOption);
   }
@@ -38,9 +32,9 @@ function ToastPlayground() {
         <img alt="Cute toast mascot" src="/toast.png" />
         <h1>Toast Playground</h1>
       </header>
-      <ToastShelf toasts={toasts} dismissToast={dismissToast} />
+      <ToastShelf />
 
-      <form onSubmit={(event) => addToastToShelf(event)}>
+      <form onSubmit={(event) => handleCreateToast(event)}>
         <div className={styles.controlsWrapper}>
           <div className={styles.row}>
             <label

--- a/src/components/ToastProvider/ToastProvider.js
+++ b/src/components/ToastProvider/ToastProvider.js
@@ -1,0 +1,12 @@
+import React from "react";
+
+export const ToastContext = React.createContext()
+
+function ToastProvider() {
+
+
+
+  return <div />;
+}
+
+export default ToastProvider;

--- a/src/components/ToastProvider/ToastProvider.js
+++ b/src/components/ToastProvider/ToastProvider.js
@@ -5,8 +5,6 @@ export const ToastContext = React.createContext();
 function ToastProvider({ children }) {
   const [toasts, setToasts] = React.useState([]);
 
-  
-
   const dismissToast = React.useCallback((id) => {
     const nextToasts = toasts.filter((item) => {
       return item.id !== id;

--- a/src/components/ToastProvider/ToastProvider.js
+++ b/src/components/ToastProvider/ToastProvider.js
@@ -12,9 +12,20 @@ function ToastProvider({ children }) {
     setToasts(nextToasts);
   });
 
+  function createToast(message, variant) {
+    // Refactor
+    const nextToast = {
+      id: crypto.randomUUID(),
+      message,
+      variant,
+    };
+
+    setToasts([...toasts, nextToast]);
+  }
+
   return (
     <ToastContext.Provider
-      value={{ toasts, setToasts, dismissToast }}
+      value={{ toasts, setToasts, dismissToast, createToast }}
     >
       {children}
     </ToastContext.Provider>

--- a/src/components/ToastProvider/ToastProvider.js
+++ b/src/components/ToastProvider/ToastProvider.js
@@ -1,12 +1,15 @@
 import React from "react";
 
-export const ToastContext = React.createContext()
+export const ToastContext = React.createContext();
 
-function ToastProvider() {
+function ToastProvider({children}) {
+  const [toasts, setToasts] = React.useState([]);
 
-
-
-  return <div />;
+  return (
+    <ToastContext.Provider value={{ toasts, setToasts }}>
+      {children}
+    </ToastContext.Provider>
+  );
 }
 
 export default ToastProvider;

--- a/src/components/ToastProvider/ToastProvider.js
+++ b/src/components/ToastProvider/ToastProvider.js
@@ -13,14 +13,16 @@ function ToastProvider({ children }) {
   });
 
   function createToast(message, variant) {
-    // Refactor
-    const nextToast = {
-      id: crypto.randomUUID(),
-      message,
-      variant,
-    };
+    const nextToasts = [
+      ...toasts,
+      {
+        id: crypto.randomUUID(),
+        message,
+        variant,
+      },
+    ];
 
-    setToasts([...toasts, nextToast]);
+    setToasts(nextToasts);
   }
 
   return (

--- a/src/components/ToastProvider/ToastProvider.js
+++ b/src/components/ToastProvider/ToastProvider.js
@@ -2,11 +2,22 @@ import React from "react";
 
 export const ToastContext = React.createContext();
 
-function ToastProvider({children}) {
+function ToastProvider({ children }) {
   const [toasts, setToasts] = React.useState([]);
 
+  
+
+  const dismissToast = React.useCallback((id) => {
+    const nextToasts = toasts.filter((item) => {
+      return item.id !== id;
+    });
+    setToasts(nextToasts);
+  });
+
   return (
-    <ToastContext.Provider value={{ toasts, setToasts }}>
+    <ToastContext.Provider
+      value={{ toasts, setToasts, dismissToast }}
+    >
       {children}
     </ToastContext.Provider>
   );

--- a/src/components/ToastProvider/index.js
+++ b/src/components/ToastProvider/index.js
@@ -1,0 +1,2 @@
+export * from "./ToastProvider";
+export { default } from "./ToastProvider";

--- a/src/components/ToastShelf/ToastShelf.js
+++ b/src/components/ToastShelf/ToastShelf.js
@@ -1,15 +1,18 @@
 import React from "react";
 
+import { ToastContext } from "../ToastProvider/ToastProvider";
 import Toast from "../Toast/Toast";
 import styles from "./ToastShelf.module.css";
 
-function ToastShelf({ dismissToast, toasts }) {
+function ToastShelf() {
+
+  const {toasts} = React.useContext(ToastContext)
   return (
     <ol className={styles.wrapper}>
       {toasts.map((item) => {
         return (
           <li className={styles.toastWrapper} key={item.id}>
-            <Toast variant={item.variant} id={item.id} dismissToast={dismissToast}>
+            <Toast variant={item.variant} id={item.id}>
               {item.message}
             </Toast>
           </li>

--- a/src/components/ToastShelf/ToastShelf.js
+++ b/src/components/ToastShelf/ToastShelf.js
@@ -5,8 +5,9 @@ import Toast from "../Toast/Toast";
 import styles from "./ToastShelf.module.css";
 
 function ToastShelf() {
-
+  
   const {toasts} = React.useContext(ToastContext)
+
   return (
     <ol className={styles.wrapper}>
       {toasts.map((item) => {


### PR DESCRIPTION
Satisfies: 
- [x] Create a new component, ToastProvider, that will serve as the “keeper” for all toast-related state.
    - [x] To generate a new component, you can use the “new-component” script! Try tunning npm run new-component ToastProvider in the terminal.
- [x] Components that require the state should pull it from context with the useContext hook, rather than passing through props.
- [x] As we saw in the [“Provider Components” lesson](https://courses.joshwcomeau.com/joy-of-react/04-component-design/08.04-provider-component), we can also share functions that allow consumers to alter the state. Consider making functions available that will create a new toast, or dismiss a specific toast.
- [x] This is a “refactor” exercise. The user experience shouldn't change at all.